### PR TITLE
New optimized methods

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -60,7 +60,10 @@ declare module '@growblocks/olap-in-memory' {
         drillUp(dimensionId: string, attribute: string, values?: string[]): Cube;
         dropMeasure(measure: string): void;
         getData(measure: string): number[];
+        getSingleData(measure: string, coords: Record<string, string>): number;
         getDimension(dimensionId: string): GenericDimension | TimeDimension;
+        getDistribution(measure: string, filter: Record<string, string[]>): number;
+        getTotalForDimensionItems(measure: string, filter: Record<string, string[]>): number;
         getNestedArray(measure: string): NestedNumberArray;
         getNestedObject(measure: string): NestedNumberObject;
         hydrateFromCube(cube: Cube): void;


### PR DESCRIPTION
Introduces 3 new methods that are used to enable use-cases of the app without too much computation. Namely: 

- `cube.getTotalForDimensionItems()`: diceByDimensionItems (most expensive) can be replaced with this one. Whenever the intent is to get the total for the sub-cube
-  `cube.getTotal()`: to be used instead of `cubeTotal` which relies on the sliceApi
-   `cube.getDistribution()`: under the hood it uses the `getTotalForDimensionItems` to check what is the sub cube total in relation to the full cube.