### PR TITLE
New method copyMeasureData

### DIFF
--- a/src/cube.js
+++ b/src/cube.js
@@ -617,6 +617,37 @@ class Cube {
         return newCube;
     }
 
+    copyMeasureData(sourceMeasureId, targetMeasureId, dimensionsFilter = {}) {
+        const _dimensionsFilter = {};
+        for (const [key, value] of Object.entries(dimensionsFilter)) {
+            if (typeof value === 'string') {
+                _dimensionsFilter[key] = [value];
+            } else {
+                _dimensionsFilter[key] = value;
+            }
+        }
+
+        const unspecifiedDimensions = this.dimensionIds.filter(
+            dimensionId => dimensionsFilter[dimensionId] === undefined
+        );
+
+        const combinations = getCombinations(
+            unspecifiedDimensions.reduce(
+                (acc, dimensionId) => ({
+                    ...acc,
+                    [dimensionId]: this.getDimension(dimensionId).getItems(),
+                }),
+                _dimensionsFilter
+            )
+        );
+
+        for (let i = 0; i < combinations.length; i++) {
+            const combination = combinations[i];
+            const value = this.getSingleData(sourceMeasureId, combination);
+            this.setSingleData(targetMeasureId, combination, value);
+        }
+    }
+
     keepDimensions(dimensionIds) {
         let cube = this;
         for (let dimension of this.dimensions) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -53,6 +53,7 @@ declare module '@growblocks/olap-in-memory' {
         clone(): Cube;
         cloneStoredMeasure(originCube: Cube, measureId: string): void;
         computedMeasures: Object;
+        copyMeasureData(sourceMeasureId, targetMeasureId, dimensionsFilter = {}): void;
         collapse(): Cube;
         dice(dimensionId: string, attribute: string, value: string[]): Cube;
         diceRange(dimensionId: string, attribute: string, start: string, end: string): Cube;


### PR DESCRIPTION
This PR adds a new method called `copyMeasureData` which will copy the data within the data space defined by `dimensionsFilter` from one measure into another.

This provides an alternative to such operation where the performance is at worst is ~O(n) where n size of the cube defined by the `dimensionsFilter`.
