### PR TITLE
new method: updateStoredMeasureRules

### DIFF
--- a/src/cube.js
+++ b/src/cube.js
@@ -527,6 +527,11 @@ class Cube {
                 );
     }
 
+    updateStoredMeasureRules(measureId, cb) {
+        const newRules = cb(this.storedMeasuresRules[measureId]);
+        this.storedMeasuresRules[measureId] = newRules;
+    }
+
     project(dimensionIds) {
         return this.keepDimensions(dimensionIds).reorderDimensions(dimensionIds);
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -103,7 +103,7 @@ declare module '@growblocks/olap-in-memory' {
         swapDimensions(dim1: string, dim2: string): Cube;
         updateStoredMeasureRules(
             measureId: string,
-            cb: (rules: Record<string, string>) => void
+            cb: (rules: Record<string, string>) => Record<string, string>
         ): void;
     }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -101,5 +101,9 @@ declare module '@growblocks/olap-in-memory' {
         storedMeasureIds: string[];
         storeSize: number;
         swapDimensions(dim1: string, dim2: string): Cube;
+        updateStoredMeasureRules(
+            measureId: string,
+            cb: (rules: Record<string, string>) => void
+        ): void;
     }
 }


### PR DESCRIPTION
Adds a new method called `updateStoredMeasureRules` that takes a measure and callback with the current rules for the selected measure injected into it. The return of the callback defines the new value for the measure stored rules.
