### PR TITLE
Fill cubes during compose

### DIFF
--- a/src/cube.js
+++ b/src/cube.js
@@ -790,7 +790,7 @@ class Cube {
      * For instance, composing a cube with sells by day, and number of open hour per week,
      * to compute average sell by opening hour per week.
      */
-    compose(otherCube, union = false) {
+    compose(otherCube, union = false, fillWith = null) {
         let newDimensions = this.dimensions.reduce((m, myDimension) => {
             const otherDimension = otherCube.getDimension(myDimension.id);
 
@@ -808,6 +808,9 @@ class Cube {
                 this.storedMeasures[measureId]._type,
                 this.storedMeasures[measureId]._defaultValue
             );
+            if (fillWith?.[measureId]) {
+                newCube.fillData(measureId, fillWith[measureId]);
+            }
             newCube.hydrateFromCube(this);
         });
         otherCube.storedMeasureIds.forEach(measureId => {
@@ -817,6 +820,9 @@ class Cube {
                 otherCube.storedMeasures[measureId]._type,
                 otherCube.storedMeasures[measureId]._defaultValue
             );
+            if (fillWith?.[measureId]) {
+                newCube.fillData(measureId, fillWith[measureId]);
+            }
             newCube.hydrateFromCube(otherCube);
         });
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,7 @@ declare module '@growblocks/olap-in-memory' {
             index?: number,
             distributionObj?: Record<string, number[]>
         ): Cube;
-        compose(cube: Cube, union: boolean): Cube;
+        compose(cube: Cube, union: boolean, fillWith?: Record<string, number> | null): Cube;
         computedMeasureIds: string[];
         convertToStoredMeasure(
             measureId: string,


### PR DESCRIPTION
when composing cubes, some combinations of dimension items will create empty spaces. By default, those spaces were being filled with the default value.
However, since now we only accept 0 or NaN as valid default values, cubes that need to be filled with 1s need that the consumer provide what the cube should be filled with.
This is a flag that we should re-evaluate having only 0 or Nan as valid default values.
